### PR TITLE
make warning about item deletion clearer

### DIFF
--- a/src/main/resources/assets/lootr/lang/en_us.json
+++ b/src/main/resources/assets/lootr/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "lootr.message.should_sneak": "Breaking the chest will delete your unique loot and items! In order to break, you must sneak while doing so.",
+  "lootr.message.should_sneak": "Breaking the chest will delete your unique loot and all items in the chest! In order to break, you must sneak while doing so.",
   "lootr.message.should_sneak2": "As loot is %s, only break if really needed.",
   "lootr.message.should_sneak3": "per-player per-chest",
   "lootr.message.cart_should_sneak": "Breaking the cart will delete your unique loot and items! In order to break, you must sneak while attacking",


### PR DESCRIPTION
I used a loot chest as a storage chest and then decided to upgrade my base. In the process of doing so, I broke the chest thinking that the items would be dropped - like any vanilla chest would do. 
I did read the warning message but thought it was only telling me about taking other players chances of unique loot away. 

Therefore I would like to propose an improved warning message.