### PR TITLE
Fix for data spam for LootR

### DIFF
--- a/src/main/java/noobanidus/mods/lootr/block/LootrBarrelBlock.java
+++ b/src/main/java/noobanidus/mods/lootr/block/LootrBarrelBlock.java
@@ -27,14 +27,6 @@ public class LootrBarrelBlock extends BarrelBlock {
   }
 
   @Override
-  public void onRemove(BlockState oldState, World world, BlockPos pos, BlockState newState, boolean isMoving) {
-    if (oldState.getBlock() != newState.getBlock() && world instanceof ServerWorld) {
-      DataStorage.deleteLootChest((ServerWorld) world, pos);
-    }
-    super.onRemove(oldState, world, pos, newState, isMoving);
-  }
-
-  @Override
   public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult trace) {
     if (player.isShiftKeyDown()) {
       ChestUtil.handleLootSneak(this, world, pos, player);

--- a/src/main/java/noobanidus/mods/lootr/block/LootrChestBlock.java
+++ b/src/main/java/noobanidus/mods/lootr/block/LootrChestBlock.java
@@ -51,14 +51,6 @@ public class LootrChestBlock extends ChestBlock {
   }
 
   @Override
-  public void onRemove(BlockState oldState, World world, BlockPos pos, BlockState newState, boolean isMoving) {
-    if (oldState.getBlock() != newState.getBlock() && world instanceof ServerWorld) {
-      DataStorage.deleteLootChest((ServerWorld) world, pos);
-    }
-    super.onRemove(oldState, world, pos, newState, isMoving);
-  }
-
-  @Override
   public boolean hasTileEntity(BlockState state) {
     return true;
   }

--- a/src/main/java/noobanidus/mods/lootr/block/LootrInventoryBlock.java
+++ b/src/main/java/noobanidus/mods/lootr/block/LootrInventoryBlock.java
@@ -51,14 +51,6 @@ public class LootrInventoryBlock extends ChestBlock {
   }
 
   @Override
-  public void onRemove(BlockState oldState, World world, BlockPos pos, BlockState newState, boolean isMoving) {
-    if (oldState.getBlock() != newState.getBlock() && world instanceof ServerWorld) {
-      DataStorage.deleteLootChest((ServerWorld) world, pos);
-    }
-    super.onRemove(oldState, world, pos, newState, isMoving);
-  }
-
-  @Override
   public boolean hasTileEntity(BlockState state) {
     return true;
   }

--- a/src/main/java/noobanidus/mods/lootr/block/LootrShulkerBlock.java
+++ b/src/main/java/noobanidus/mods/lootr/block/LootrShulkerBlock.java
@@ -110,9 +110,6 @@ public class LootrShulkerBlock extends ShulkerBoxBlock {
 
   @Override
   public void onRemove(BlockState pState, World pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
-    if (pState.getBlock() != pNewState.getBlock() && pLevel instanceof ServerWorld) {
-      DataStorage.deleteLootChest((ServerWorld) pLevel, pPos);
-    }
 
     if (!pState.is(pNewState.getBlock())) {
       TileEntity tileentity = pLevel.getBlockEntity(pPos);

--- a/src/main/java/noobanidus/mods/lootr/block/LootrTrappedChestBlock.java
+++ b/src/main/java/noobanidus/mods/lootr/block/LootrTrappedChestBlock.java
@@ -38,14 +38,6 @@ public class LootrTrappedChestBlock extends TrappedChestBlock {
   }
 
   @Override
-  public void onRemove(BlockState oldState, World world, BlockPos pos, BlockState newState, boolean isMoving) {
-    if (oldState.getBlock() != newState.getBlock() && world instanceof ServerWorld) {
-      DataStorage.deleteLootChest((ServerWorld) world, pos);
-    }
-    super.onRemove(oldState, world, pos, newState, isMoving);
-  }
-
-  @Override
   public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult trace) {
     if (player.isShiftKeyDown()) {
       ChestUtil.handleLootSneak(this, world, pos, player);

--- a/src/main/java/noobanidus/mods/lootr/block/tile/LootrChestTileEntity.java
+++ b/src/main/java/noobanidus/mods/lootr/block/tile/LootrChestTileEntity.java
@@ -38,7 +38,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import noobanidus.mods.lootr.Lootr;
 import noobanidus.mods.lootr.api.tile.ILootTile;
 import noobanidus.mods.lootr.config.ConfigManager;
-import noobanidus.mods.lootr.data.SpecialChestInventory;
+import noobanidus.mods.lootr.data.old.SpecialChestInventory;
 import noobanidus.mods.lootr.init.ModBlocks;
 import noobanidus.mods.lootr.init.ModTiles;
 

--- a/src/main/java/noobanidus/mods/lootr/data/ContainerData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/ContainerData.java
@@ -17,6 +17,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import noobanidus.mods.lootr.Lootr;
 import noobanidus.mods.lootr.api.LootFiller;
 import noobanidus.mods.lootr.api.tile.ILootTile;
 import noobanidus.mods.lootr.data.old.SpecialChestInventory;
@@ -82,8 +83,12 @@ public class ContainerData
 		};
 	}
 	
-	public SpecialChestInventory getInventory()
+	public SpecialChestInventory getInventory(BlockPos pos)
 	{
+		if(inventory != null)
+		{
+			inventory.setBlockPos(pos);
+		}
 		return inventory;
 	}
 	

--- a/src/main/java/noobanidus/mods/lootr/data/ContainerData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/ContainerData.java
@@ -1,0 +1,212 @@
+package noobanidus.mods.lootr.data;
+
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.ItemStackHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import noobanidus.mods.lootr.api.LootFiller;
+import noobanidus.mods.lootr.api.tile.ILootTile;
+import noobanidus.mods.lootr.data.old.SpecialChestInventory;
+import noobanidus.mods.lootr.entity.LootrChestMinecartEntity;
+
+public class ContainerData
+{
+	private BlockPos pos;
+	private RegistryKey<World> dimension;
+	private UUID entityId;
+	private UUID tileId;
+	private UUID customId;
+	private SpecialChestInventory inventory;
+	private NonNullList<ItemStack> reference;
+	private boolean custom;
+	
+	public ContainerData()
+	{
+	}
+	
+	public ContainerData(RegistryKey<World> dimension, UUID id, @Nullable UUID customId, @Nullable NonNullList<ItemStack> base)
+	{
+		this.dimension = dimension;
+		this.tileId = id;
+		this.reference = base;
+		this.custom = true;
+		this.customId = customId;
+		if(customId == null && base == null)
+		{
+			throw new IllegalArgumentException("Both customId and inventory reference cannot be null.");
+		}
+	}
+	
+	public ContainerData(RegistryKey<World> dimension, UUID id)
+	{
+		this.dimension = dimension;
+		this.tileId = id;
+	}
+	
+	public ContainerData(RegistryKey<World> dimension, BlockPos pos)
+	{
+		this.pos = pos;
+		this.dimension = dimension;
+	}
+	
+	public ContainerData(UUID entityId)
+	{
+		this.entityId = entityId;
+	}
+	
+	public UUID getEntityId()
+	{
+		return entityId;
+	}
+	
+	public LootFiller customInventory()
+	{
+		return (player, inventory, table, seed) -> {
+			for(int i = 0;i < reference.size();i++)
+			{
+				inventory.setItem(i, reference.get(i).copy());
+			}
+		};
+	}
+	
+	public SpecialChestInventory getInventory()
+	{
+		return inventory;
+	}
+	
+	public SpecialChestInventory createInventory(ServerPlayerEntity player, LootFiller filler, @Nullable LockableLootTileEntity tile)
+	{
+		ServerWorld world = (ServerWorld)player.level;
+		if(entityId != null)
+		{
+			Entity initial = world.getEntity(entityId);
+			if(!(initial instanceof LootrChestMinecartEntity))
+			{
+				return null;
+			}
+			LootrChestMinecartEntity cart = (LootrChestMinecartEntity)initial;
+			NonNullList<ItemStack> items = NonNullList.withSize(cart.getContainerSize(), ItemStack.EMPTY);
+			// Saving this is handled elsewhere
+			SpecialChestInventory result = new SpecialChestInventory(this, items, cart.getDisplayName(), pos);
+			filler.fillWithLoot(player, result, cart.lootTable, -1);
+			inventory = result;
+			return result;
+		}
+		else
+		{
+			if(world.dimension() != dimension)
+			{
+				world = world.getServer().getLevel(dimension);
+			}
+			if(world == null || tile == null)
+			{
+				return null;
+			}
+			NonNullList<ItemStack> items = NonNullList.withSize(tile.getContainerSize(), ItemStack.EMPTY);
+			// Saving this is handled elsewhere
+			SpecialChestInventory result = new SpecialChestInventory(this, items, tile.getDisplayName(), pos);
+			filler.fillWithLoot(player, result, ((ILootTile)tile).getTable(), -1);
+			inventory = result;
+			return result;
+		}
+	}
+	
+	public void load(CompoundNBT compound)
+	{
+		if(compound.contains("position"))
+		{
+			pos = BlockPos.of(compound.getLong("position"));
+		}
+		if(compound.contains("dimension"))
+		{
+			dimension = RegistryKey.create(Registry.DIMENSION_REGISTRY, new ResourceLocation(compound.getString("dimension")));
+		}
+		if(compound.hasUUID("entityId"))
+		{
+			entityId = compound.getUUID("entityId");
+		}
+		if(compound.hasUUID("tileId"))
+		{
+			tileId = compound.getUUID("tileId");
+		}
+		if(compound.contains("custom"))
+		{
+			custom = compound.getBoolean("custom");
+		}
+		if(compound.hasUUID("customId"))
+		{
+			customId = compound.getUUID("customId");
+		}
+		if(compound.contains("reference") && compound.contains("referenceSize"))
+		{
+			int size = compound.getInt("referenceSize");
+			reference = NonNullList.withSize(size, ItemStack.EMPTY);
+			ItemStackHelper.loadAllItems(compound.getCompound("reference"), reference);
+		}
+		if(compound.contains("inventory"))
+		{
+			CompoundNBT data = compound.getCompound("inventory");
+			inventory = new SpecialChestInventory(this, data.getCompound("chest"), data.getString("name"), pos);
+		}
+	}
+	
+	public CompoundNBT save(CompoundNBT compound)
+	{
+		if(pos != null)
+		{
+			compound.putLong("position", pos.asLong());
+		}
+		if(dimension != null)
+		{
+			compound.putString("dimension", dimension.location().toString());
+		}
+		if(entityId != null)
+		{
+			compound.putUUID("entityId", entityId);
+		}
+		if(tileId != null)
+		{
+			compound.putUUID("tileId", tileId);
+		}
+		if(customId != null)
+		{
+			compound.putUUID("customId", customId);
+		}
+		if(custom)
+		{
+			compound.putBoolean("custom", custom);
+		}
+		if(reference != null)
+		{
+			compound.putInt("referenceSize", reference.size());
+			compound.put("reference", ItemStackHelper.saveAllItems(new CompoundNBT(), reference, true));
+		}
+		if(inventory != null)
+		{
+			CompoundNBT data = new CompoundNBT();
+			data.put("chest", inventory.writeItems());
+			data.putString("name", inventory.writeName());
+			compound.put("inventory", data);
+		}
+		return compound;
+	}
+	
+	public void clear()
+	{
+		inventory = null;
+	}
+	
+}

--- a/src/main/java/noobanidus/mods/lootr/data/DataStorage.java
+++ b/src/main/java/noobanidus/mods/lootr/data/DataStorage.java
@@ -138,7 +138,7 @@ public class DataStorage {
     }
 
     ContainerData data = getInstanceUuid(player.getUUID(), (ServerWorld) world, uuid);
-    SpecialChestInventory inventory = data.getInventory();
+    SpecialChestInventory inventory = data.getInventory(pos);
     if (inventory == null) {
       inventory = data.createInventory(player, filler, tile);
       inventory.setBlockPos(pos);
@@ -159,7 +159,7 @@ public class DataStorage {
       return null;
     }
     ContainerData data = getInstanceInventory(player.getUUID(), (ServerWorld) world, uuid, null, base);
-    SpecialChestInventory inventory = data.getInventory();
+    SpecialChestInventory inventory = data.getInventory(pos);
     if (inventory == null) {
       inventory = data.createInventory(player, data.customInventory(), tile);
       inventory.setBlockPos(pos);
@@ -227,7 +227,7 @@ public class DataStorage {
     }
 
     ContainerData data = getInstance(player.getUUID(), cart.getUUID());
-    SpecialChestInventory inventory = data.getInventory();
+    SpecialChestInventory inventory = data.getInventory(null);
     if (inventory == null) {
       inventory = data.createInventory(player, filler, null);
     }

--- a/src/main/java/noobanidus/mods/lootr/data/DecayData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/DecayData.java
@@ -1,0 +1,73 @@
+package noobanidus.mods.lootr.data;
+
+import java.util.UUID;
+
+import it.unimi.dsi.fastutil.objects.Object2LongLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap.Entry;
+import it.unimi.dsi.fastutil.objects.Object2LongMaps;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraft.world.storage.WorldSavedData;
+import net.minecraftforge.common.util.Constants;
+
+public class DecayData extends WorldSavedData
+{
+	Object2LongMap<UUID> decayTime = new Object2LongLinkedOpenHashMap<>();
+	
+	public DecayData(String id)
+	{
+		super(id);
+	}
+	
+	public static DecayData getDecay() {
+		return new DecayData("Lootr-Decay-Data");
+	}
+	
+	@Override
+	public void load(CompoundNBT compound)
+	{
+		ListNBT list = compound.getList("decay", Constants.NBT.TAG_COMPOUND);
+		for(int i = 0,m=list.size();i<m;i++) {
+			CompoundNBT data = list.getCompound(i);
+			decayTime.put(data.getUUID("id"), data.getLong("time"));
+		}
+	}
+	
+	@Override
+	public CompoundNBT save(CompoundNBT compound)
+	{
+		ListNBT list = new ListNBT();
+		for(ObjectIterator<Entry<UUID>> iter = Object2LongMaps.fastIterator(decayTime);iter.hasNext();) {
+			Entry<UUID> entry = iter.next();
+			CompoundNBT data = new CompoundNBT();
+			data.putUUID("id", entry.getKey());
+			data.putLong("time", entry.getLongValue());
+			list.add(data);
+		}
+		if(list.size() > 0) {
+			compound.put("decay", list);
+		}
+		return compound;
+	}
+	
+	public void markDecayed(UUID id, long nextTime) {
+		decayTime.put(id, nextTime);	
+		setDirty();
+	}
+	
+	public boolean isDecayed(UUID id, long currentTime) {
+		return decayTime.getLong(id) < currentTime;
+	}
+	
+	public int getDecayTime(UUID id, long currentTime) {
+		return (int)(currentTime - decayTime.getLong(id));
+	}
+	
+	public void removeDecay(UUID id) {
+		if(decayTime.removeLong(id) != 0) {
+			setDirty();
+		}
+	}
+}

--- a/src/main/java/noobanidus/mods/lootr/data/DecayData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/DecayData.java
@@ -58,11 +58,12 @@ public class DecayData extends WorldSavedData
 	}
 	
 	public boolean isDecayed(UUID id, long currentTime) {
-		return decayTime.getLong(id) < currentTime;
+		long time = decayTime.getLong(id);
+		return time > 0 && time < currentTime;
 	}
 	
 	public int getDecayTime(UUID id, long currentTime) {
-		return (int)(currentTime - decayTime.getLong(id));
+		return (int)(Math.max(decayTime.getLong(id) - currentTime, -1));
 	}
 	
 	public void removeDecay(UUID id) {

--- a/src/main/java/noobanidus/mods/lootr/data/PlayerData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/PlayerData.java
@@ -1,0 +1,78 @@
+package noobanidus.mods.lootr.data;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraftforge.common.util.Constants;
+
+public class PlayerData
+{
+	Statistics stats = new Statistics();
+	TimedData time = new TimedData();
+	Map<UUID, ContainerData> mappedContainers = new Object2ObjectLinkedOpenHashMap<>();
+	
+	public PlayerData()
+	{
+	}
+	
+	public CompoundNBT save(long currentTime)
+	{
+		CompoundNBT data = new CompoundNBT();
+		putIfHasData(data, "stats", stats.save(new CompoundNBT()));
+		putIfHasData(data, "timed", time.save(new CompoundNBT(), currentTime));
+		ListNBT list = new ListNBT();
+		for(Map.Entry<UUID, ContainerData> entry : mappedContainers.entrySet())
+		{
+			CompoundNBT compound = entry.getValue().save(new CompoundNBT());
+			if(compound.isEmpty()) continue;
+			compound.putUUID("storage_id", entry.getKey());
+			list.add(compound);
+		}
+		if(list.size() > 0)  {
+			data.put("inventories", list);
+		}
+		return data;
+	}
+	
+	public PlayerData load(CompoundNBT nbt)
+	{
+		stats.load(nbt.getCompound("stats"));
+		time.load(nbt.getCompound("timed"));
+		ListNBT list = nbt.getList("inventories", Constants.NBT.TAG_COMPOUND);
+		for(int i = 0;i<list.size();i++) {
+			CompoundNBT data = list.getCompound(i);
+			ContainerData container = new ContainerData();
+			container.save(data);
+			mappedContainers.put(data.getUUID("storage_id"), container);
+		}
+		return this;
+	}
+	
+	private void putIfHasData(CompoundNBT data, String key, CompoundNBT toAdd)
+	{
+		if(toAdd.isEmpty()) return;
+		data.put(key, toAdd);
+	}
+	
+	public ContainerData getOrCreate(UUID id, Supplier<ContainerData> provider)
+	{
+		return mappedContainers.computeIfAbsent(id, T -> provider.get());
+	}
+	
+	public TimedData getTimedData() {
+		return time;
+	}
+	
+	public Statistics getStats() {
+		return stats;
+	}
+	
+	public void clearPlayerData() {
+		mappedContainers.clear();
+	}
+}

--- a/src/main/java/noobanidus/mods/lootr/data/PlayerData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/PlayerData.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraftforge.common.util.Constants;
@@ -20,11 +19,11 @@ public class PlayerData
 	{
 	}
 	
-	public CompoundNBT save(long currentTime)
+	public CompoundNBT save()
 	{
 		CompoundNBT data = new CompoundNBT();
 		putIfHasData(data, "stats", stats.save(new CompoundNBT()));
-		putIfHasData(data, "timed", time.save(new CompoundNBT(), currentTime));
+		putIfHasData(data, "timed", time.save(new CompoundNBT()));
 		ListNBT list = new ListNBT();
 		for(Map.Entry<UUID, ContainerData> entry : mappedContainers.entrySet())
 		{
@@ -47,7 +46,7 @@ public class PlayerData
 		for(int i = 0;i<list.size();i++) {
 			CompoundNBT data = list.getCompound(i);
 			ContainerData container = new ContainerData();
-			container.save(data);
+			container.load(data);
 			mappedContainers.put(data.getUUID("storage_id"), container);
 		}
 		return this;

--- a/src/main/java/noobanidus/mods/lootr/data/Statistics.java
+++ b/src/main/java/noobanidus/mods/lootr/data/Statistics.java
@@ -1,0 +1,64 @@
+package noobanidus.mods.lootr.data;
+
+import java.util.Set;
+import java.util.UUID;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.INBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraftforge.common.util.Constants;
+import noobanidus.mods.lootr.data.old.AdvancementData;
+import noobanidus.mods.lootr.data.old.AdvancementData.UUIDPair;
+
+public class Statistics
+{
+	Set<UUID> awards = new ObjectOpenHashSet<>();
+	Set<UUID> stats = new ObjectOpenHashSet<>();
+	
+	public void award(UUID id) {
+		awards.add(id);
+	}
+	
+	public boolean hasAward(UUID id) {
+		return awards.contains(id);
+	}
+	
+	public void score(UUID id) {
+		stats.add(id);
+	}
+	
+	public boolean isScored(UUID id) {
+		return stats.contains(id);
+	}
+		
+	public CompoundNBT save(CompoundNBT nbt) {
+		ListNBT list = new ListNBT();
+		for(UUID id : awards) {
+			list.add(NBTUtil.createUUID(id));
+		}
+		if(list.size() > 0) {
+			nbt.put("awards", list);
+		}
+		list = new ListNBT();
+		for(UUID id : stats) {
+			list.add(NBTUtil.createUUID(id));
+		}
+		if(list.size() > 0) {
+			nbt.put("scores", list);
+		}
+		return nbt;
+	}
+	
+	public void load(CompoundNBT nbt) {
+	    ListNBT list = nbt.getList("awards", Constants.NBT.TAG_INT_ARRAY);
+	    for(INBT data : list) {
+	    	awards.add(NBTUtil.loadUUID(data));
+	    }
+	    list = nbt.getList("scores", Constants.NBT.TAG_INT_ARRAY);
+	    for(INBT data : list) {
+	    	stats.add(NBTUtil.loadUUID(data));
+	    }
+	}
+}

--- a/src/main/java/noobanidus/mods/lootr/data/TimedData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/TimedData.java
@@ -1,0 +1,72 @@
+package noobanidus.mods.lootr.data;
+
+import java.util.UUID;
+
+import it.unimi.dsi.fastutil.objects.Object2LongLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap.Entry;
+import it.unimi.dsi.fastutil.objects.Object2LongMaps;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraftforge.common.util.Constants;
+
+public class TimedData
+{
+	Object2LongMap<UUID> refreshTime = new Object2LongLinkedOpenHashMap<>();
+	
+	public CompoundNBT save(CompoundNBT nbt, long currentTime)
+	{
+
+		ListNBT list = saveMap(refreshTime, currentTime);
+		if(list.size() > 0) {
+			nbt.put("refresh", list);
+		}
+		return nbt;
+	}
+	
+	public void load(CompoundNBT data) 
+	{
+		loadMap(refreshTime, data.getList("refresh", Constants.NBT.TAG_COMPOUND));
+	}
+	
+	private void loadMap(Object2LongMap<UUID> map, ListNBT list) {
+		for(int i = 0,m=list.size();i<m;i++) {
+			CompoundNBT data = list.getCompound(i);
+			map.put(data.getUUID("id"), data.getLong("time"));
+		}
+	}
+	
+	private ListNBT saveMap(Object2LongMap<UUID> map, long time) {
+		ListNBT list = new ListNBT();
+		for(ObjectIterator<Entry<UUID>> iter = Object2LongMaps.fastIterator(map);iter.hasNext();) {
+			Entry<UUID> entry = iter.next();
+			if(entry.getLongValue() < time) {
+				iter.remove();
+				continue;
+			}
+			CompoundNBT data = new CompoundNBT();
+			data.putUUID("id", entry.getKey());
+			data.putLong("time", entry.getLongValue());
+			list.add(data);
+		}
+		return list;
+	}
+
+	
+	public void markRefresh(UUID id, long nextTime) {
+		refreshTime.put(id, nextTime);
+	}
+	
+	public boolean isRefreshed(UUID id, long currentTime) {
+		return refreshTime.getLong(id) < currentTime;
+	}
+	
+	public int getRefreshTimeLeft(UUID id, long currentTime) {
+		return (int)(currentTime - refreshTime.getLong(id));
+	}
+	
+	public void removeRefresh(UUID id) {
+		refreshTime.removeLong(id);
+	}
+}

--- a/src/main/java/noobanidus/mods/lootr/data/old/AdvancementData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/old/AdvancementData.java
@@ -1,15 +1,18 @@
-package noobanidus.mods.lootr.data;
+package noobanidus.mods.lootr.data.old;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
 
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
-
-import javax.annotation.Nonnull;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import noobanidus.mods.lootr.data.Statistics;
 
 public class AdvancementData extends WorldSavedData {
   private final Set<UUIDPair> data = new HashSet<>();
@@ -28,6 +31,18 @@ public class AdvancementData extends WorldSavedData {
 
   public void add(UUID first, UUID second) {
     add(new UUIDPair(first, second));
+  }
+  
+  public void migrateAwards(Function<UUID, Statistics> data) {
+	  for(UUIDPair pair : this.data) {
+		  data.apply(pair.getFirst()).award(pair.getSecond());
+	  }
+  }
+  
+  public void migrateScore(Function<UUID, Statistics> data) {
+	  for(UUIDPair pair : this.data) {
+		  data.apply(pair.getFirst()).score(pair.getSecond());
+	  }
   }
 
   public void add(UUIDPair pair) {

--- a/src/main/java/noobanidus/mods/lootr/data/old/SpecialChestInventory.java
+++ b/src/main/java/noobanidus/mods/lootr/data/old/SpecialChestInventory.java
@@ -1,4 +1,6 @@
-package noobanidus.mods.lootr.data;
+package noobanidus.mods.lootr.data.old;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,13 +19,12 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import noobanidus.mods.lootr.api.inventory.ILootrInventory;
 import noobanidus.mods.lootr.api.tile.ILootTile;
+import noobanidus.mods.lootr.data.ContainerData;
 import noobanidus.mods.lootr.entity.LootrChestMinecartEntity;
-
-import javax.annotation.Nullable;
 
 @SuppressWarnings("NullableProblems")
 public class SpecialChestInventory implements ILootrInventory {
-  private final ChestData chestData;
+  private final ContainerData chestData;
   private final NonNullList<ItemStack> contents;
   private final ITextComponent name;
 
@@ -31,18 +32,33 @@ public class SpecialChestInventory implements ILootrInventory {
   private BlockPos pos;
 
   public SpecialChestInventory(ChestData chestData, NonNullList<ItemStack> contents, ITextComponent name, @Nullable BlockPos pos) {
-    this.chestData = chestData;
+    this.chestData = null;
     this.contents = contents;
     this.name = name;
     this.pos = pos;
   }
 
   public SpecialChestInventory(ChestData chestData, CompoundNBT items, String componentAsJSON, BlockPos pos) {
-    this.chestData = chestData;
+    this.chestData = null;
     this.name = ITextComponent.Serializer.fromJson(componentAsJSON);
     this.contents = NonNullList.withSize(27, ItemStack.EMPTY);
     ItemStackHelper.loadAllItems(items, this.contents);
     this.pos = pos;
+  }
+  
+  public SpecialChestInventory(ContainerData containerData, CompoundNBT items, String componentAsJSON, BlockPos pos) {
+    this.chestData = containerData;
+    this.name = ITextComponent.Serializer.fromJson(componentAsJSON);
+    this.contents = NonNullList.withSize(27, ItemStack.EMPTY);
+    ItemStackHelper.loadAllItems(items, this.contents);
+    this.pos = pos;
+  }
+
+  public SpecialChestInventory(ContainerData containerData, NonNullList<ItemStack> contents, ITextComponent name, BlockPos pos) {
+	  chestData = containerData;
+	  this.contents = contents;
+	  this.name = name;
+	  this.pos = pos;
   }
 
   public void setBlockPos(BlockPos pos) {
@@ -138,7 +154,6 @@ public class SpecialChestInventory implements ILootrInventory {
 
   @Override
   public void setChanged() {
-    chestData.setDirty();
   }
 
   @Override

--- a/src/main/java/noobanidus/mods/lootr/data/old/SpecialChestInventory.java
+++ b/src/main/java/noobanidus/mods/lootr/data/old/SpecialChestInventory.java
@@ -17,6 +17,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import noobanidus.mods.lootr.Lootr;
 import noobanidus.mods.lootr.api.inventory.ILootrInventory;
 import noobanidus.mods.lootr.api.tile.ILootTile;
 import noobanidus.mods.lootr.data.ContainerData;

--- a/src/main/java/noobanidus/mods/lootr/data/old/TickingData.java
+++ b/src/main/java/noobanidus/mods/lootr/data/old/TickingData.java
@@ -1,13 +1,17 @@
-package noobanidus.mods.lootr.data;
+package noobanidus.mods.lootr.data.old;
+
+import java.util.Collection;
+import java.util.UUID;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants;
-
-import java.util.UUID;
+import noobanidus.mods.lootr.data.DecayData;
+import noobanidus.mods.lootr.data.TimedData;
 
 public class TickingData extends WorldSavedData {
   private final Object2IntMap<UUID> tickMap = new Object2IntOpenHashMap<>();
@@ -32,7 +36,21 @@ public class TickingData extends WorldSavedData {
   public int removeDone(UUID id) {
     return tickMap.removeInt(id);
   }
-
+  
+  public void migrateDecay(DecayData data, long delay) {
+	  for(Entry<UUID> ids : tickMap.object2IntEntrySet()) {
+		  data.markDecayed(ids.getKey(), delay + ids.getIntValue());
+	  }
+  }
+  
+  public void migrateRefresh(Collection<TimedData> timeData, long delay) {
+	 for(TimedData data : timeData) {
+		 for(Entry<UUID> ids : tickMap.object2IntEntrySet()) {
+			 data.markRefresh(ids.getKey(), delay + ids.getIntValue());
+		 }
+	 }
+  }
+  
   public boolean tick() {
     if (tickMap.isEmpty()) {
       return false;

--- a/src/main/java/noobanidus/mods/lootr/entity/EntityTicker.java
+++ b/src/main/java/noobanidus/mods/lootr/entity/EntityTicker.java
@@ -15,15 +15,17 @@ import noobanidus.mods.lootr.data.DataStorage;
 import java.util.ArrayList;
 import java.util.List;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
 @Mod.EventBusSubscriber(modid = Lootr.MODID)
 public class EntityTicker {
-  private static final List<LootrChestMinecartEntity> entities = new ArrayList<>();
+  private static final List<LootrChestMinecartEntity> ENTITIES = new ObjectArrayList<>();
 
   @SubscribeEvent
   public static void onServerTick(TickEvent.ServerTickEvent event) {
     if (event.phase == TickEvent.Phase.END) {
-      entities.removeIf(Entity::isAddedToWorld);
-      for (LootrChestMinecartEntity entity : entities) {
+      ENTITIES.removeIf(Entity::isAddedToWorld);
+      for (LootrChestMinecartEntity entity : ENTITIES) {
         ServerWorld world = (ServerWorld) entity.level;
         ServerChunkProvider provider = world.getChunkSource();
         IChunk ichunk = provider.getChunk(MathHelper.floor(entity.getX() / 16.0D), MathHelper.floor(entity.getZ() / 16.0D), ChunkStatus.FULL, false);
@@ -31,12 +33,10 @@ public class EntityTicker {
           world.addFreshEntity(entity);
         }
       }
-      DataStorage.doDecay();
-      DataStorage.doRefresh();
     }
   }
 
   public static void addEntity(LootrChestMinecartEntity entity) {
-    entities.add(entity);
+    ENTITIES.add(entity);
   }
 }

--- a/src/main/java/noobanidus/mods/lootr/event/HandleData.java
+++ b/src/main/java/noobanidus/mods/lootr/event/HandleData.java
@@ -1,0 +1,196 @@
+package noobanidus.mods.lootr.event;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.SharedConstants;
+import net.minecraft.util.Util;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.DimensionSavedDataManager;
+import net.minecraft.world.storage.FolderName;
+import net.minecraft.world.storage.WorldSavedData;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import noobanidus.mods.lootr.Lootr;
+import noobanidus.mods.lootr.data.ContainerData;
+import noobanidus.mods.lootr.data.DataStorage;
+import noobanidus.mods.lootr.data.DecayData;
+import noobanidus.mods.lootr.data.PlayerData;
+import noobanidus.mods.lootr.data.Statistics;
+import noobanidus.mods.lootr.data.old.AdvancementData;
+import noobanidus.mods.lootr.data.old.ChestData;
+import noobanidus.mods.lootr.data.old.TickingData;
+
+@Mod.EventBusSubscriber(modid = Lootr.MODID)
+public class HandleData
+{
+	private static final Set<UUID> MARK_FOR_REMOVAL = new ObjectOpenHashSet<>();
+	
+	@SubscribeEvent
+	public static void onWorldLoaded(WorldEvent.Load event)
+	{
+		IWorld world = event.getWorld();
+		if(world instanceof ServerWorld)
+		{
+			ServerWorld server = (ServerWorld)world;
+			if(server.dimension() == World.OVERWORLD)
+			{
+				switch(migrateFiles(server.getServer().getWorldPath(new FolderName("data")), server.getServer().getWorldPath(FolderName.PLAYER_DATA_DIR).toFile(), server))
+				{
+					case SUCCESS:
+						Lootr.LOG.info("Successfully Migrated Data to new System");
+						break;
+					case FAIL:
+						Lootr.LOG.error("Couldn't migrate data to new System");
+						break;
+					default:
+						break;
+				}
+			}
+		}
+	}
+	
+	public static ActionResultType migrateFiles(Path path, File playerPath, ServerWorld world)
+	{
+		List<String> ids = new ArrayList<>();
+		try(Stream<Path> paths = Files.walk(path))
+		{
+			paths.forEach(o -> {
+				if(Files.isRegularFile(o))
+				{
+					String name = o.getFileName().toString();
+					if(name.startsWith("Lootr-") && !name.endsWith("Data.dat"))
+					{
+						ids.add(name.replace(".dat", ""));
+					}
+				}
+			});
+		}
+		catch(IOException e)
+		{
+			return ActionResultType.FAIL;
+		}
+		if(ids.isEmpty()) return ActionResultType.PASS;
+		Map<UUID, PlayerData> migrationMap = new Object2ObjectLinkedOpenHashMap<>();
+		Function<UUID, PlayerData> playerData = T -> loadData(new File(playerPath, "lootR_" + T.toString() + ".dat"));
+		BiFunction<UUID, UUID, ContainerData> containerGetter = (P, T) -> migrationMap.computeIfAbsent(P, playerData).getOrCreate(T, () -> new ContainerData());
+		Function<UUID, Statistics> statsGetter = T -> migrationMap.computeIfAbsent(T, playerData).getStats();
+		DimensionSavedDataManager manager = world.getDataStorage();
+		long time = world.getGameTime();
+		ids.forEach(id -> migrate(manager, path, id, ChestData::new, T -> T.migrate(containerGetter)));
+		migrate(manager, path, "Lootr-AdvancementData", AdvancementData::new, T -> T.migrateAwards(statsGetter));
+		migrate(manager, path, "Lootr-ScoreData", AdvancementData::new, T -> T.migrateScore(statsGetter));
+		migrate(manager, path, "Lootr-RefreshData", TickingData::new, T -> T.migrateRefresh(Lists.transform(new ObjectArrayList<>(migrationMap.values()), PlayerData::getTimedData), time));
+		migrate(manager, path, "Lootr-DecayData", TickingData::new, T -> T.migrateDecay(manager.computeIfAbsent(DecayData::getDecay, "Lootr-Decay-Data"), time));
+		for(Map.Entry<UUID, PlayerData> entry : migrationMap.entrySet())
+		{
+			saveData(playerPath, entry.getKey().toString(), entry.getValue().save(time));
+		}
+		
+		return ActionResultType.SUCCESS;
+	}
+	
+	private static <T extends WorldSavedData> void migrate(DimensionSavedDataManager manager, Path path, String id, Function<String, T> creator, Consumer<T> migrator) {
+		if(Files.notExists(path.resolve(id+".dat"))) return;
+		try
+		{
+			T created = creator.apply(id);
+			created.load(manager.readTagFromDisk(id, SharedConstants.getCurrentVersion().getWorldVersion()).getCompound("data"));
+			migrator.accept(created);
+			Files.deleteIfExists(path.resolve(id+".dat"));
+		}
+		catch(Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+	
+	@SubscribeEvent
+	public static void onPlayerLoaded(PlayerEvent.LoadFromFile event)
+	{
+		try
+		{
+			File file = new File(event.getPlayerDirectory(), "lootR_" + event.getPlayerUUID() + ".dat");
+			if(file.exists() && file.isFile())
+			{
+				DataStorage.DATA.put(event.getPlayer().getUUID(), loadData(file));
+			}
+		}
+		catch(Exception e)
+		{
+			e.printStackTrace();
+			DataStorage.DATA.put(event.getPlayer().getUUID(), new PlayerData());
+		}
+	}
+	
+	@SubscribeEvent
+	public static void onPlayerSaved(PlayerEvent.SaveToFile event)
+	{
+		UUID id = event.getPlayer().getUUID();
+		CompoundNBT data = DataStorage.DATA.getOrDefault(id, new PlayerData()).save(event.getPlayer().level.getGameTime());
+		saveData(event.getPlayerDirectory(), event.getPlayerUUID(), data);
+		if(MARK_FOR_REMOVAL.contains(id))
+		{
+			DataStorage.DATA.remove(data);
+		}
+	}
+	
+	@SubscribeEvent
+	public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event)
+	{
+		MARK_FOR_REMOVAL.add(event.getPlayer().getUUID());
+	}
+	
+	private static void saveData(File file, String playerUUID, CompoundNBT data) {
+		try
+		{
+			File temp = File.createTempFile("lootR_" + playerUUID + "-", "_.dat", file);
+			CompressedStreamTools.writeCompressed(data, temp);
+			File current = new File(file, "lootR_" + playerUUID + ".dat");
+			File old = new File(file, "lootR_" + playerUUID + ".dat_old");
+			Util.safeReplaceFile(current, temp, old);
+		}
+		catch(Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+	
+	private static PlayerData loadData(File file) {
+		if(file.exists() && file.isFile())
+		{
+			try
+			{
+				return new PlayerData().load(CompressedStreamTools.readCompressed(file));
+			}
+			catch(IOException e)
+			{
+				e.printStackTrace();
+			}
+		}
+		return new PlayerData();
+	}
+}

--- a/src/main/java/noobanidus/mods/lootr/event/HandleData.java
+++ b/src/main/java/noobanidus/mods/lootr/event/HandleData.java
@@ -107,7 +107,7 @@ public class HandleData
 		migrate(manager, path, "Lootr-DecayData", TickingData::new, T -> T.migrateDecay(manager.computeIfAbsent(DecayData::getDecay, "Lootr-Decay-Data"), time));
 		for(Map.Entry<UUID, PlayerData> entry : migrationMap.entrySet())
 		{
-			saveData(playerPath, entry.getKey().toString(), entry.getValue().save(time));
+			saveData(playerPath, entry.getKey().toString(), entry.getValue().save());
 		}
 		
 		return ActionResultType.SUCCESS;
@@ -150,7 +150,7 @@ public class HandleData
 	public static void onPlayerSaved(PlayerEvent.SaveToFile event)
 	{
 		UUID id = event.getPlayer().getUUID();
-		CompoundNBT data = DataStorage.DATA.getOrDefault(id, new PlayerData()).save(event.getPlayer().level.getGameTime());
+		CompoundNBT data = DataStorage.DATA.getOrDefault(id, new PlayerData()).save();
 		saveData(event.getPlayerDirectory(), event.getPlayerUUID(), data);
 		if(MARK_FOR_REMOVAL.contains(id))
 		{

--- a/src/main/java/noobanidus/mods/lootr/util/ChestUtil.java
+++ b/src/main/java/noobanidus/mods/lootr/util/ChestUtil.java
@@ -1,5 +1,10 @@
 package noobanidus.mods.lootr.util;
 
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
 import net.minecraft.block.BarrelBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.ChestBlock;
@@ -29,11 +34,6 @@ import noobanidus.mods.lootr.init.ModAdvancements;
 import noobanidus.mods.lootr.init.ModStats;
 import noobanidus.mods.lootr.networking.CloseCart;
 import noobanidus.mods.lootr.networking.PacketHandler;
-
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
 
 @SuppressWarnings("unused")
 public class ChestUtil {
@@ -84,18 +84,18 @@ public class ChestUtil {
     TileEntity te = world.getBlockEntity(pos);
     if (te instanceof ILootTile) {
       UUID tileId = ((ILootTile) te).getTileId();
-      if (DataStorage.isDecayed(tileId)) {
+      if (DataStorage.isDecayed(tileId, world.getGameTime())) {
         world.destroyBlock(pos, true);
         DataStorage.removeDecayed(tileId);
         player.sendMessage(new TranslationTextComponent("lootr.message.decayed").setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
         return false;
       } else {
-        int decayValue = DataStorage.getDecayValue(tileId);
+        int decayValue = DataStorage.getDecayValue(tileId, world.getGameTime());
         if (decayValue > 0) {
           player.sendMessage(new TranslationTextComponent("lootr.message.decay_in", decayValue / 20).setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
         } else if (decayValue == -1) {
           if (ConfigManager.isDecaying(world, (ILootTile) te)) {
-            DataStorage.setDecaying(tileId, ConfigManager.DECAY_VALUE.get());
+            DataStorage.setDecaying(tileId, world.getGameTime() + ConfigManager.DECAY_VALUE.get());
             player.sendMessage(new TranslationTextComponent("lootr.message.decay_start", ConfigManager.DECAY_VALUE.get() / 20).setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
           }
         }
@@ -107,17 +107,17 @@ public class ChestUtil {
       } else if (block instanceof LootrShulkerBlock) {
         ModAdvancements.SHULKER_PREDICATE.trigger((ServerPlayerEntity) player, ((ILootTile) te).getTileId());
       }
-      if (DataStorage.isRefreshed(tileId)) {
+      if (DataStorage.isRefreshed(player.getUUID(), tileId, world.getGameTime())) {
         DataStorage.refreshInventory(world, ((ILootTile) te).getTileId(), (ServerPlayerEntity) player);
-        DataStorage.removeRefreshed(tileId);
+        DataStorage.removeRefreshed(player.getUUID(), tileId);
         player.sendMessage(new TranslationTextComponent("lootr.message.refreshed").setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
       } else {
-        int refreshValue = DataStorage.getRefreshValue(tileId);
+        int refreshValue = DataStorage.getRefreshValue(player.getUUID(), tileId, world.getGameTime());
         if (refreshValue > 0) {
           player.sendMessage(new TranslationTextComponent("lootr.message.refresh_in", refreshValue / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
         } else if (refreshValue == -1) {
           if (ConfigManager.isRefreshing(world, (ILootTile) te)) {
-            DataStorage.setRefreshing(tileId, ConfigManager.REFRESH_VALUE.get());
+            DataStorage.setRefreshing(player.getUUID(), tileId, world.getGameTime() + ConfigManager.REFRESH_VALUE.get());
             player.sendMessage(new TranslationTextComponent("lootr.message.refresh_start", ConfigManager.REFRESH_VALUE.get() / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
           }
         }
@@ -142,18 +142,18 @@ public class ChestUtil {
         player.openMenu(null);
       } else {
         UUID tileId = cart.getUUID();
-        if (DataStorage.isDecayed(tileId)) {
+        if (DataStorage.isDecayed(tileId, world.getGameTime())) {
           cart.destroy(DamageSource.OUT_OF_WORLD);
           DataStorage.removeDecayed(tileId);
           player.sendMessage(new TranslationTextComponent("lootr.message.decayed").setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
           return;
         } else {
-          int decayValue = DataStorage.getDecayValue(tileId);
+          int decayValue = DataStorage.getDecayValue(tileId, world.getGameTime());
           if (decayValue > 0) {
             player.sendMessage(new TranslationTextComponent("lootr.message.decay_in", decayValue / 20).setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
           } else if (decayValue == -1) {
             if (ConfigManager.isDecaying(world, cart)) {
-              DataStorage.setDecaying(tileId, ConfigManager.DECAY_VALUE.get());
+              DataStorage.setDecaying(tileId, world.getGameTime() + ConfigManager.DECAY_VALUE.get());
               player.sendMessage(new TranslationTextComponent("lootr.message.decay_start", ConfigManager.DECAY_VALUE.get() / 20).setStyle(Style.EMPTY.withColor(TextFormatting.RED).withBold(true)), Util.NIL_UUID);
             }
           }
@@ -168,17 +168,17 @@ public class ChestUtil {
           ModAdvancements.SCORE_PREDICATE.trigger((ServerPlayerEntity) player, null);
           DataStorage.score(player.getUUID(), cart.getUUID());
         }
-        if (DataStorage.isRefreshed(tileId)) {
+        if (DataStorage.isRefreshed(player.getUUID(), tileId, world.getGameTime())) {
           DataStorage.refreshInventory(world, cart, (ServerPlayerEntity) player);
-          DataStorage.removeRefreshed(tileId);
+          DataStorage.removeRefreshed(player.getUUID(), tileId);
           player.sendMessage(new TranslationTextComponent("lootr.message.refreshed").setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
         } else {
-          int refreshValue = DataStorage.getRefreshValue(tileId);
+          int refreshValue = DataStorage.getRefreshValue(player.getUUID(), tileId, world.getGameTime());
           if (refreshValue > 0) {
             player.sendMessage(new TranslationTextComponent("lootr.message.refresh_in", refreshValue / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
           } else if (refreshValue == -1) {
             if (ConfigManager.isRefreshing(world, cart)) {
-              DataStorage.setRefreshing(tileId, ConfigManager.REFRESH_VALUE.get());
+              DataStorage.setRefreshing(player.getUUID(), tileId, world.getGameTime() + ConfigManager.REFRESH_VALUE.get());
               player.sendMessage(new TranslationTextComponent("lootr.message.refresh_start", ConfigManager.REFRESH_VALUE.get() / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
             }
           }
@@ -206,17 +206,17 @@ public class ChestUtil {
         stacks = copyItemList(tile.getCustomInventory());
       }
       UUID tileId = tile.getTileId();
-      if (DataStorage.isRefreshed(tileId)) {
+      if (DataStorage.isRefreshed(player.getUUID(), tileId, world.getGameTime())) {
         DataStorage.refreshInventory(world, ((ILootTile) te).getTileId(), stacks, (ServerPlayerEntity) player);
-        DataStorage.removeRefreshed(tileId);
+        DataStorage.removeRefreshed(player.getUUID(), tileId);
         player.sendMessage(new TranslationTextComponent("lootr.message.refreshed").setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
       } else {
-        int refreshValue = DataStorage.getRefreshValue(tileId);
+        int refreshValue = DataStorage.getRefreshValue(player.getUUID(), tileId, world.getGameTime());
         if (refreshValue > 0) {
           player.sendMessage(new TranslationTextComponent("lootr.message.refresh_in", refreshValue / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
         } else if (refreshValue == -1) {
           if (ConfigManager.isRefreshing(world, tile)) {
-            DataStorage.setRefreshing(tileId, ConfigManager.REFRESH_VALUE.get());
+            DataStorage.setRefreshing(player.getUUID(), tileId, world.getGameTime() + ConfigManager.REFRESH_VALUE.get());
             player.sendMessage(new TranslationTextComponent("lootr.message.refresh_start", ConfigManager.REFRESH_VALUE.get() / 20).setStyle(Style.EMPTY.withColor(TextFormatting.BLUE).withBold(true)), Util.NIL_UUID);
           }
         }

--- a/src/main/java/noobanidus/mods/lootr/util/ChestUtil.java
+++ b/src/main/java/noobanidus/mods/lootr/util/ChestUtil.java
@@ -24,6 +24,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.network.PacketDistributor;
+import noobanidus.mods.lootr.Lootr;
 import noobanidus.mods.lootr.api.tile.ILootTile;
 import noobanidus.mods.lootr.block.LootrShulkerBlock;
 import noobanidus.mods.lootr.block.tile.LootrInventoryTileEntity;


### PR DESCRIPTION
This is a fully functioning & tested fix for lootRs data storage.

What did I change?
LootR now stores everything in independent files in the player folder that only has 1-2 files per player.
Since everything (except decay) is based around player actions, we can save everything inside the player.
If the player logs off the file is automatically unloaded with it.
If you worry about memory leaks this is exactly the same amount of memory usage as before.
Just a cleaner file system and some performance improvements thanks to the better dealing of "timed data".

Also this includes a fully functioning migration service that automigrates everything on worldload.

I hope this helps.

Changelog:
-Fixed: Spamming of Files that don't use any space and will never unload once loaded until server restart.
-Added: LootR data is now saved in player specific files when the player logs off the files will be unloaded.
-Fixed: If to many chests are in the Decay/Refresh queue they could lag. Now using a better system to do the same job. (Works even if players are logged off)
-Added: Migration System that automatically converts old system into the new System.
-Fixed: Cleaning of Player Specfic data is now 1000x faster because the data is now mapped per player instead of per chest/minecart.