### PR TITLE
Fixed crash with litematica(/forgematica) when a schematic is loaded

### DIFF
--- a/src/main/java/noobanidus/mods/lootr/block/tile/TileTicker.java
+++ b/src/main/java/noobanidus/mods/lootr/block/tile/TileTicker.java
@@ -36,7 +36,7 @@ public class TileTicker {
   private final static Set<Entry> pendingEntries = new ObjectLinkedOpenHashSet<>();
 
   public static void addEntry(World level, BlockPos position) {
-    if (level.isClientSide()) {
+    if (level.isClientSide() || ServerLifecycleHooks.getCurrentServer() == null) {
       return;
     }
 


### PR DESCRIPTION
Hi,
I was having this confusing issue with forge 1.16.5 and forgematica, where as soon as i would load a schematic, my game would crash. After looking at the logs a bit i realised something on line 53 (creation of entry) was null,
```
[13Mar2024 12:00:25.951] [Render thread/FATAL] [net.minecraft.client.Minecraft/]: Unreported exception thrown!
java.lang.NullPointerException: null
	at noobanidus.mods.lootr.block.tile.TileTicker.addEntry(TileTicker.java:53) ~[lootr:0.2.18.49]
	at net.minecraft.world.World.handler$ddm000$lootrAddBlockEntity(World.java:5184) ~[?:?]
	at net.minecraft.world.World.func_175700_a(World.java:444) ~[?:?]
	at net.minecraft.world.World.func_175690_a(World.java:641) ~[?:?]
	at net.minecraft.world.chunk.Chunk.func_177424_a(Chunk.java:391) ~[?:?]
	at net.minecraft.world.World.func_175625_s(World.java:598) ~[?:?]
	at net.minecraft.world.World.func_175713_t(World.java:649) ~[?:?]
	at fi.dy.masa.litematica.world.ChunkSchematic.func_177436_a(ChunkSchematic.java:96) ~[forgematica:?]
	at fi.dy.masa.litematica.world.WorldSchematic.func_180501_a(WorldSchematic.java:136) ~[forgematica:?]
	at fi.dy.masa.litematica.util.SchematicPlacingUtils.placeBlocksWithinChunk(SchematicPlacingUtils.java:211) ~[forgematica:?]
	at fi.dy.masa.litematica.util.SchematicPlacingUtils.placeToWorldWithinChunk(SchematicPlacingUtils.java:65) ~[forgematica:?]
	at fi.dy.masa.litematica.schematic.placement.SchematicPlacementManager.processQueuedChunks(SchematicPlacementManager.java:152) ~[forgematica:?]
	at fi.dy.masa.litematica.scheduler.ClientTickHandler.onClientTick(ClientTickHandler.java:31) ~[forgematica:?]
	at fi.dy.masa.malilib.event.TickHandler.onClientTick(TickHandler.java:36) ~[mafglib:?]
	at fi.dy.masa.malilib.compat.forge.event.ForgeTickEventHandler.onClientTickEnd(ForgeTickEventHandler.java:15) ~[mafglib:?]
	at net.minecraftforge.eventbus.ASMEventHandler_1298_ForgeTickEventHandler_onClientTickEnd_ClientTickEvent.invoke(.dynamic) ~[?:?]
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?]
	at net.minecraftforge.fml.hooks.BasicEventHooks.onPostClientTick(BasicEventHooks.java:96) ~[forge:?]
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1544) ~[?:?]
	at net.minecraft.client.Minecraft.func_195542_b(Minecraft.java:954) ~[?:?]
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:607) ~[?:?]
	at net.minecraft.client.main.Main.main(Main.java:184) ~[minecraft-1.16.5-client.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_361]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_361]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_361]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_361]
	at net.minecraftforge.fml.loading.FMLClientLaunchProvider.lambda$launchService$0(FMLClientLaunchProvider.java:37) ~[forge-1.16.5-36.2.39-launcher.jar:36.2]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-8.1.3.jar:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:54) [modlauncher-8.1.3.jar:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:72) [modlauncher-8.1.3.jar:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:82) [modlauncher-8.1.3.jar:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:66) [modlauncher-8.1.3.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_361]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_361]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_361]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_361]
	at io.github.zekerzhayard.forgewrapper.installer.Main.main(Main.java:67) [ForgeWrapper-prism-2024-02-29.jar:prism-2024-02-29]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:87) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:130) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]

```
The only thing that could've caused this was the MinecraftServer being null, which made sense since I am playing on a server, so the minecraft server would be null, but my loaded schematic would only show client sided, so maybe that's why it was going through the `level.isClientSide()`? (level wasnt client side but the entries to be added were). I just added a null check to the client side check and it no longer crashes with forgematica, and seems to work well.

