### PR TITLE
[Fabric 1.20] Refactor DynamicItemRenderer usage to fix remapping to Yarn

### DIFF
--- a/src/main/java/net/zestyblaze/lootr/client/LootrClient.java
+++ b/src/main/java/net/zestyblaze/lootr/client/LootrClient.java
@@ -31,16 +31,16 @@ public class LootrClient implements ClientModInitializer {
     BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.BARREL, RenderType.cutoutMipped());
 
     BlockEntityRenderers.register(ModBlockEntities.SPECIAL_LOOT_CHEST, LootrChestBlockRenderer::new);
-    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.CHEST, LootrChestItemRenderer.getInstance());
+    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.CHEST, LootrChestItemRenderer.getInstance().getDynamicItemRenderer());
 
     BlockEntityRenderers.register(ModBlockEntities.SPECIAL_TRAPPED_LOOT_CHEST, LootrChestBlockRenderer::new);
-    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.TRAPPED_CHEST, LootrChestItemRenderer.getInstance());
+    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.TRAPPED_CHEST, LootrChestItemRenderer.getInstance().getDynamicItemRenderer());
 
     BlockEntityRenderers.register(ModBlockEntities.SPECIAL_LOOT_INVENTORY, LootrChestBlockRenderer::new);
-    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.INVENTORY, LootrChestItemRenderer.getInstance());
+    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.INVENTORY, LootrChestItemRenderer.getInstance().getDynamicItemRenderer());
 
     BlockEntityRenderers.register(ModBlockEntities.SPECIAL_LOOT_SHULKER, LootrShulkerBlockRenderer::new);
-    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SHULKER, LootrShulkerItemRenderer.getInstance());
+    BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SHULKER, LootrShulkerItemRenderer.getInstance().getDynamicItemRenderer());
 
     ModelLoadingRegistry.INSTANCE.registerResourceProvider(o -> new BarrelModel.BarrelModelLoader());
 

--- a/src/main/java/net/zestyblaze/lootr/client/item/LootrChestItemRenderer.java
+++ b/src/main/java/net/zestyblaze/lootr/client/item/LootrChestItemRenderer.java
@@ -15,7 +15,7 @@ import net.zestyblaze.lootr.block.entities.LootrChestBlockEntity;
 import net.zestyblaze.lootr.entity.LootrChestMinecartEntity;
 import net.zestyblaze.lootr.init.ModBlocks;
 
-public class LootrChestItemRenderer extends BlockEntityWithoutLevelRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+public class LootrChestItemRenderer extends BlockEntityWithoutLevelRenderer {
   private static LootrChestItemRenderer INSTANCE = null;
 
   private BlockEntityRenderDispatcher blockEntityRenderDispatcher;
@@ -39,13 +39,13 @@ public class LootrChestItemRenderer extends BlockEntityWithoutLevelRenderer impl
     return INSTANCE;
   }
 
+  public BuiltinItemRendererRegistry.DynamicItemRenderer getDynamicItemRenderer() {
+    return this::renderByItem;
+  }
+
   @Override
   public void renderByItem(ItemStack stack, ItemDisplayContext mode, PoseStack matrixStack, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
     getBlockEntityRenderDispatcher().renderItem(tile, matrixStack, buffer, combinedLight, combinedOverlay);
-  }
-
-  public void render(ItemStack stack, ItemDisplayContext mode, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
-    renderByItem(stack, mode, matrices, vertexConsumers, light, overlay);
   }
 
   public void renderByMinecart(LootrChestMinecartEntity entity, PoseStack matrixStack, MultiBufferSource buffer, int combinedLight) {

--- a/src/main/java/net/zestyblaze/lootr/client/item/LootrShulkerItemRenderer.java
+++ b/src/main/java/net/zestyblaze/lootr/client/item/LootrShulkerItemRenderer.java
@@ -13,7 +13,7 @@ import net.minecraft.world.item.ItemStack;
 import net.zestyblaze.lootr.block.entities.LootrShulkerBlockEntity;
 import net.zestyblaze.lootr.init.ModBlocks;
 
-public class LootrShulkerItemRenderer extends BlockEntityWithoutLevelRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+public class LootrShulkerItemRenderer extends BlockEntityWithoutLevelRenderer {
   private static LootrShulkerItemRenderer INSTANCE = null;
 
   private BlockEntityRenderDispatcher blockEntityRenderDispatcher;
@@ -36,14 +36,13 @@ public class LootrShulkerItemRenderer extends BlockEntityWithoutLevelRenderer im
     return INSTANCE;
   }
 
-  @Override
-  public void renderByItem(ItemStack stack, ItemDisplayContext mode, PoseStack matrixStack, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
-    getBlockEntityRenderDispatcher().renderItem(tile, matrixStack, buffer, combinedLight, combinedOverlay);
+  public BuiltinItemRendererRegistry.DynamicItemRenderer getDynamicItemRenderer() {
+    return this::renderByItem;
   }
 
   @Override
-  public void render(ItemStack stack, ItemDisplayContext mode, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
-    renderByItem(stack, mode, matrices, vertexConsumers, light, overlay);
+  public void renderByItem(ItemStack stack, ItemDisplayContext mode, PoseStack matrixStack, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
+    getBlockEntityRenderDispatcher().renderItem(tile, matrixStack, buffer, combinedLight, combinedOverlay);
   }
 
   private BlockEntityRenderDispatcher getBlockEntityRenderDispatcher() {


### PR DESCRIPTION
With Yarn mappings, `renderByItem` gets remapped to `render`, which has the same signature as `DynamicItemRenderer#render`, thus causing "unfixable conflicts" when remapping Lootr when it's used as a dependency. This PR changes how `DynamicItemRenderer` is implemented (wherever it's used), allowing Lootr to be depended upon by mods that use Yarn.