### PR TITLE
Add translations for the Trophy and fix itemGroup title

### DIFF
--- a/common/src/generated/resources/assets/lootr/lang/en_us.json
+++ b/common/src/generated/resources/assets/lootr/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/af_za.json
+++ b/common/src/main/resources/assets/lootr/lang/af_za.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/ar_sa.json
+++ b/common/src/main/resources/assets/lootr/lang/ar_sa.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/ca_es.json
+++ b/common/src/main/resources/assets/lootr/lang/ca_es.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/cs_cz.json
+++ b/common/src/main/resources/assets/lootr/lang/cs_cz.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/da_dk.json
+++ b/common/src/main/resources/assets/lootr/lang/da_dk.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/de_de.json
+++ b/common/src/main/resources/assets/lootr/lang/de_de.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/el_gr.json
+++ b/common/src/main/resources/assets/lootr/lang/el_gr.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/es_es.json
+++ b/common/src/main/resources/assets/lootr/lang/es_es.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Barril de Botín",
   "block.lootr.lootr_chest": "Cofre de Botín",
   "block.lootr.lootr_inventory": "Cofre de Botín",

--- a/common/src/main/resources/assets/lootr/lang/es_mx.json
+++ b/common/src/main/resources/assets/lootr/lang/es_mx.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Barril de Botín",
   "block.lootr.lootr_chest": "Cofre de Botín",
   "block.lootr.lootr_inventory": "Cofre de Botín",

--- a/common/src/main/resources/assets/lootr/lang/fi_fi.json
+++ b/common/src/main/resources/assets/lootr/lang/fi_fi.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/fr_fr.json
+++ b/common/src/main/resources/assets/lootr/lang/fr_fr.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Tonneau de Butin",
   "block.lootr.lootr_chest": "Coffre de Butin",
   "block.lootr.lootr_inventory": "Coffre de Butin",

--- a/common/src/main/resources/assets/lootr/lang/he_il.json
+++ b/common/src/main/resources/assets/lootr/lang/he_il.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/hu_hu.json
+++ b/common/src/main/resources/assets/lootr/lang/hu_hu.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/it_it.json
+++ b/common/src/main/resources/assets/lootr/lang/it_it.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/ja_jp.json
+++ b/common/src/main/resources/assets/lootr/lang/ja_jp.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "お宝樽",
   "block.lootr.lootr_chest": "お宝チェスト",
   "block.lootr.lootr_inventory": "お宝チェスト",

--- a/common/src/main/resources/assets/lootr/lang/ko_kr.json
+++ b/common/src/main/resources/assets/lootr/lang/ko_kr.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "전리품 통",
   "block.lootr.lootr_chest": "전리품 상자",
   "block.lootr.lootr_inventory": "전리품 상자",

--- a/common/src/main/resources/assets/lootr/lang/lol_us.json
+++ b/common/src/main/resources/assets/lootr/lang/lol_us.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Luut Fish Box",
   "block.lootr.lootr_chest": "Luut Cat Box",
   "block.lootr.lootr_inventory": "Luut Cat Box",

--- a/common/src/main/resources/assets/lootr/lang/nl_nl.json
+++ b/common/src/main/resources/assets/lootr/lang/nl_nl.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/no_no.json
+++ b/common/src/main/resources/assets/lootr/lang/no_no.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/pl_pl.json
+++ b/common/src/main/resources/assets/lootr/lang/pl_pl.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Beczka z łupami",
   "block.lootr.lootr_chest": "Skrzynia z łupami",
   "block.lootr.lootr_inventory": "Skrzynia z łupami",

--- a/common/src/main/resources/assets/lootr/lang/pt_br.json
+++ b/common/src/main/resources/assets/lootr/lang/pt_br.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Barril de loot",
   "block.lootr.lootr_chest": "Baú de loot",
   "block.lootr.lootr_inventory": "Baú de loot",

--- a/common/src/main/resources/assets/lootr/lang/pt_pt.json
+++ b/common/src/main/resources/assets/lootr/lang/pt_pt.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/ro_ro.json
+++ b/common/src/main/resources/assets/lootr/lang/ro_ro.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/ru_ru.json
+++ b/common/src/main/resources/assets/lootr/lang/ru_ru.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Бочка с добычей",
   "block.lootr.lootr_chest": "Сундук с добычей",
   "block.lootr.lootr_inventory": "Сундук с добычей",

--- a/common/src/main/resources/assets/lootr/lang/sr_sp.json
+++ b/common/src/main/resources/assets/lootr/lang/sr_sp.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/sv_se.json
+++ b/common/src/main/resources/assets/lootr/lang/sv_se.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Skattunna",
   "block.lootr.lootr_chest": "Skattkista",
   "block.lootr.lootr_inventory": "Skattkista",

--- a/common/src/main/resources/assets/lootr/lang/tr_tr.json
+++ b/common/src/main/resources/assets/lootr/lang/tr_tr.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Ganimet Fıçısı",
   "block.lootr.lootr_chest": "Ganimet Sandığı",
   "block.lootr.lootr_inventory": "Ganimet Sandığı",

--- a/common/src/main/resources/assets/lootr/lang/uk_ua.json
+++ b/common/src/main/resources/assets/lootr/lang/uk_ua.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Бочка зі здобиччю",
   "block.lootr.lootr_chest": "Скриня зі здобиччю",
   "block.lootr.lootr_inventory": "Скриня зі здобиччю",

--- a/common/src/main/resources/assets/lootr/lang/vi_vn.json
+++ b/common/src/main/resources/assets/lootr/lang/vi_vn.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "Loot Barrel",
   "block.lootr.lootr_chest": "Loot Chest",
   "block.lootr.lootr_inventory": "Loot Chest",

--- a/common/src/main/resources/assets/lootr/lang/zh_cn.json
+++ b/common/src/main/resources/assets/lootr/lang/zh_cn.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "战利品木桶",
   "block.lootr.lootr_chest": "战利品箱子",
   "block.lootr.lootr_inventory": "战利品箱子",

--- a/common/src/main/resources/assets/lootr/lang/zh_tw.json
+++ b/common/src/main/resources/assets/lootr/lang/zh_tw.json
@@ -1,4 +1,5 @@
 {
+  "block.lootr.trophy": "Loot Trophy",
   "block.lootr.lootr_barrel": "戰利品木桶",
   "block.lootr.lootr_chest": "戰利品箱",
   "block.lootr.lootr_inventory": "戰利品箱",

--- a/neoforge/src/main/java/noobanidus/mods/lootr/neoforge/init/ModTabs.java
+++ b/neoforge/src/main/java/noobanidus/mods/lootr/neoforge/init/ModTabs.java
@@ -14,7 +14,7 @@ public class ModTabs {
   private static final DeferredRegister<CreativeModeTab> REGISTER = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, LootrAPI.MODID);
 
   public static final DeferredHolder<CreativeModeTab, CreativeModeTab> LOOTR = REGISTER.register("lootr", () -> CreativeModeTab.builder()
-      .title(Component.translatable("itemGroup.lootr"))
+      .title(Component.translatable("itemGroup.lootr.lootr"))
       .icon(() -> new ItemStack(LootrRegistry.getTrophyItem()))
       .displayItems((p, output) -> {
         output.accept(LootrRegistry.getTrophyBlock());


### PR DESCRIPTION
This adds "block.lootr.trophy" translations to each language file for the Trophy. By default I did "Loot Trophy", but I was thinking "Lootr Trophy' also works, let me know if you want it changed. I have also fixed the itemGroup title.