### PR TITLE
Fix NPE in hopper entity-container prevention

### DIFF
--- a/common/src/main/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntity.java
+++ b/common/src/main/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntity.java
@@ -32,7 +32,9 @@ public class MixinHopperBlockEntity {
   @WrapMethod(method="getEntityContainer")
   private static Container lootr$preventHopperEntityInteraction(Level level, double x, double y, double z, Operation<Container> original) {
     var result = original.call(level, x, y, z);
-    Entity entity = (Entity) result;
+    if (!(result instanceof Entity entity)) {
+      return result;
+    }
     if (entity.is(LootrTags.Entity.CONTAINERS)) {
       return null;
     }


### PR DESCRIPTION
`lootr$preventHopperEntityInteraction` wraps vanilla `getEntityContainer`, which returns `null` when no container entity is at the probed position. The wrapper casts the result to `Entity` and calls `entity.is(...)` with no null check, so any hopper scanning a spot without a container entity throws an NPE (`Cannot invoke "...Entity.is(...)" because "entity" is null`).

Guarded with a pattern `instanceof` so a null/non-entity result passes through unchanged, restoring the null-safety the pre-26 wrapper had. Same one-line fix filed against `mdg-26.2` separately (identical file): #862
