### PR TITLE
perf(save): offload LootrSavedData disk writes to background thread to prevent watchdog timeouts

### DIFF
--- a/common/src/main/java/noobanidus/mods/lootr/common/data/LootrSavedData.java
+++ b/common/src/main/java/noobanidus/mods/lootr/common/data/LootrSavedData.java
@@ -264,7 +264,17 @@ public class LootrSavedData extends SavedData implements ILootrSavedData {
   public void save(File pFile, HolderLookup.Provider provider) {
     if (isDirty()) {
       pFile.getParentFile().mkdirs();
+      CompoundTag compoundTag = new CompoundTag();
+      compoundTag.put("data", this.save(new CompoundTag(), provider));
+      compoundTag.putInt("DataVersion", net.minecraft.SharedConstants.getCurrentVersion().getDataVersion().getVersion());
+      setDirty(false);
+      noobanidus.mods.lootr.common.command.IOUtil.withIOWorker(() -> {
+        try {
+          net.minecraft.nbt.NbtIo.writeCompressed(compoundTag, pFile.toPath());
+        } catch (java.io.IOException e) {
+          LootrAPI.LOG.error("Failed to save Lootr data asynchronously to {}", pFile, e);
+        }
+      });
     }
-    super.save(pFile, provider);
   }
 }


### PR DESCRIPTION
### Async NBT Save for LootrSavedData — Fix Watchdog Timeouts

**Problem**

Servers with a large number of opened loot containers experience watchdog crashes during world auto-saves. The root cause is that the default SavedData#save(File, HolderLookup.Provider) implementation calls NbtIo.writeCompressed directly on the main server thread. Since Lootr persists each container as a separate .dat file, a world with thousands of opened chests can block the server tick thread for well over 60 seconds, triggering the watchdog timeout.

**Solution**

Override save(File, HolderLookup.Provider) in LootrSavedData to:
1. Serialize the current in-memory state into a CompoundTag **synchronously** on the main thread — this is safe and fast.
2. Call setDirty(false) immediately to prevent redundant save scheduling.
3. Delegate the compression and file write (NbtIo.writeCompressed) to the existing IOUtil.withIOWorker background queue, keeping the server tick thread unblocked.

This approach reuses the single-threaded worker already present in the codebase for async file operations, avoiding the introduction of a new thread pool.

**Thread Safety**

The serialized CompoundTag is constructed synchronously before being handed off to the background worker, so there is no concurrent access to live game objects. The worst-case failure scenario — a hard crash between queuing the write and its completion — results in a recently opened chest reverting to its unopened state on the next server start. There is no risk of file or world corruption.

**Testing**

- Full \./gradlew build\ completed successfully on both Fabric and NeoForge targets.
- Verified loot container state persists correctly across server restarts.
- No changes to the NBT format or file layout; fully backwards compatible with existing worlds.