### PR TITLE
Fix weathered copper chest advancement trigger typo (mdg-26.2)

### DIFF
--- a/common/src/generated/resources/data/lootr/advancement/weathered_copper_chest.json
+++ b/common/src/generated/resources/data/lootr/advancement/weathered_copper_chest.json
@@ -2,7 +2,7 @@
   "parent": "lootr:exposed_copper_chest",
   "criteria": {
     "weathered_copper_opened": {
-      "trigger": "lootr:weatherd_copper_chest"
+      "trigger": "lootr:weathered_copper_chest"
     }
   },
   "display": {

--- a/neoforge/src/main/java/noobanidus/mods/lootr/neoforge/init/ModAdvancements.java
+++ b/neoforge/src/main/java/noobanidus/mods/lootr/neoforge/init/ModAdvancements.java
@@ -26,7 +26,7 @@ public class ModAdvancements {
   public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> ITEM_FRAME = REGISTER.register("item_frame_looted", ContainerTrigger::new);
   public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> COPPER_CHEST = REGISTER.register("copper_chest", ContainerTrigger::new);
   public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> EXPOSED_COPPER_CHEST = REGISTER.register("exposed_copper_chest", ContainerTrigger::new);
-  public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> WEATHERED_COPPER_CHEST = REGISTER.register("weatherd_copper_chest", ContainerTrigger::new);
+  public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> WEATHERED_COPPER_CHEST = REGISTER.register("weathered_copper_chest", ContainerTrigger::new);
   public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> OXIDIZED_COPPER_CHEST = REGISTER.register("oxidized_copper_chest", ContainerTrigger::new);
   public static final DeferredHolder<CriterionTrigger<?>, ContainerTrigger> TRAPPED_CHEST = REGISTER.register("trapped_chest", ContainerTrigger::new);
 


### PR DESCRIPTION
The generated advancement `common/src/generated/resources/data/lootr/advancement/weathered_copper_chest.json` uses the trigger `lootr:weatherd_copper_chest`, missing the "e" in "weathered".

That spelling matches `neoforge/src/main/java/noobanidus/mods/lootr/neoforge/init/ModAdvancements.java`, which registers the trigger under the same typo, so datagen writes it out that way. Fabric's `ModAdvancements` registers `lootr:weathered_copper_chest` instead. The generated data ships in both jars, so on Fabric the advancement points at a trigger that was never registered and gets dropped during load. `lootr:oxidized_copper_chest` and `lootr:all_copper` are its children, so they go with it. Three advancements are unobtainable on Fabric.

Seen on `lootr-fabric-26.1.2-1.23.38.119`.

This changes the NeoForge registration to the correct spelling and updates the generated JSON to match. Fabric needed no change, it was already correct.

Worth knowing before merging: this changes a registered trigger id on NeoForge. The criterion key inside the advancement (`weathered_copper_opened`) is unchanged, so anyone who already earned the advancement keeps it, and players partway through will re-trigger on the next weathered copper chest they open.

Two caveats on my end. I edited the generated file by hand instead of running datagen, and I have not built either loader locally. Happy to redo it through the generator if you would rather have it that way.

`mdg-26.1.2` has the same bug. Same commit for that branch in #875.
