### PR TITLE
Guard non-entity hopper containers on 1.21.1

### DIFF
--- a/common/src/main/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntity.java
+++ b/common/src/main/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntity.java
@@ -32,8 +32,10 @@ public class MixinHopperBlockEntity {
   @WrapMethod(method = "getEntityContainer")
   private static Container lootr$preventHopperEntityInteraction(Level level, double x, double y, double z, Operation<Container> original) {
     var result = original.call(level, x, y, z);
-    Entity entity = (Entity) result;
-    if (entity == null || entity.getType().is(LootrTags.Entity.CONTAINERS)) {
+    if (!(result instanceof Entity entity)) {
+      return result;
+    }
+    if (entity.getType().is(LootrTags.Entity.CONTAINERS)) {
       return null;
     }
     if (LootrAPI.resolveEntity(entity) instanceof ILootrEntity) {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 
     implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${rootProject.mixin_extras_version}"))
     implementation("io.github.llamalad7:mixinextras-fabric:${rootProject.mixin_extras_version}")
+
+    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.mockito:mockito-core:5.14.2"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 publishMods {
@@ -188,6 +193,10 @@ loom {
 
 tasks.named("compileJava", JavaCompile) {
     source(project.project(":common").sourceSets.main.allJava)
+}
+
+tasks.named("test", Test) {
+    useJUnitPlatform()
 }
 
 tasks.named("javadoc", Javadoc).configure {

--- a/fabric/src/test/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntityTest.java
+++ b/fabric/src/test/java/noobanidus/mods/lootr/common/mixin/hopper/MixinHopperBlockEntityTest.java
@@ -1,0 +1,138 @@
+package noobanidus.mods.lootr.common.mixin.hopper;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.vehicle.AbstractMinecartContainer;
+import net.minecraft.world.level.Level;
+import noobanidus.mods.lootr.common.api.ILootrAPI;
+import noobanidus.mods.lootr.common.api.LootrAPI;
+import noobanidus.mods.lootr.common.api.LootrTags;
+import noobanidus.mods.lootr.common.api.data.entity.ILootrEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class MixinHopperBlockEntityTest {
+  private static final Method PREVENT_HOPPER_ENTITY_INTERACTION = findMethod();
+
+  private ILootrAPI previousApi;
+  private ILootrAPI api;
+
+  @BeforeAll
+  static void bootstrapMinecraft() {
+    SharedConstants.tryDetectVersion();
+    Bootstrap.bootStrap();
+  }
+
+  @BeforeEach
+  void setUp() {
+    previousApi = LootrAPI.INSTANCE;
+    api = mock(ILootrAPI.class);
+    LootrAPI.INSTANCE = api;
+  }
+
+  @AfterEach
+  void tearDown() {
+    LootrAPI.INSTANCE = previousApi;
+  }
+
+  @Test
+  void returnsNullResultUnchangedWithoutLootrChecks() {
+    assertNull(invokeWrapper(null));
+
+    verifyNoInteractions(api);
+  }
+
+  @Test
+  void returnsNonEntityContainerUnchangedWithoutLootrChecks() {
+    Container container = mock(Container.class);
+
+    assertSame(container, invokeWrapper(container));
+    verifyNoInteractions(api);
+  }
+
+  @Test
+  void returnsOrdinaryEntityContainerUnchanged() {
+    AbstractMinecartContainer container = entityContainer(false);
+
+    assertSame(container, invokeWrapper(container));
+    verify(api).resolveEntity(container);
+  }
+
+  @Test
+  void blocksTaggedLootrContainerEntityWithoutResolvingIt() {
+    AbstractMinecartContainer container = entityContainer(true);
+
+    assertNull(invokeWrapper(container));
+    verify(api, never()).resolveEntity(any());
+  }
+
+  @Test
+  void blocksEntityResolvedAsLootrEntity() {
+    AbstractMinecartContainer container = entityContainer(false);
+    ILootrEntity resolved = mock(ILootrEntity.class);
+    when(api.resolveEntity(container)).thenReturn(resolved);
+
+    assertNull(invokeWrapper(container));
+    verify(api).resolveEntity(container);
+  }
+
+  private AbstractMinecartContainer entityContainer(boolean tagged) {
+    AbstractMinecartContainer container = mock(AbstractMinecartContainer.class);
+    EntityType<?> entityType = mock(EntityType.class);
+    doReturn(entityType).when(container).getType();
+    when(entityType.is(LootrTags.Entity.CONTAINERS)).thenReturn(tagged);
+    return container;
+  }
+
+  private Container invokeWrapper(Container result) {
+    Operation<Container> original = args -> result;
+    try {
+      return (Container) PREVENT_HOPPER_ENTITY_INTERACTION.invoke(
+          null, null, 0.0, 0.0, 0.0, original);
+    } catch (InvocationTargetException exception) {
+      if (exception.getCause() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      if (exception.getCause() instanceof Error error) {
+        throw error;
+      }
+      throw new AssertionError(exception.getCause());
+    } catch (ReflectiveOperationException exception) {
+      throw new AssertionError(exception);
+    }
+  }
+
+  private static Method findMethod() {
+    try {
+      Method method = MixinHopperBlockEntity.class.getDeclaredMethod(
+          "lootr$preventHopperEntityInteraction",
+          Level.class,
+          double.class,
+          double.class,
+          double.class,
+          Operation.class);
+      method.setAccessible(true);
+      return method;
+    } catch (ReflectiveOperationException exception) {
+      throw new ExceptionInInitializerError(exception);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Return non-entity `Container` results from `getEntityContainer` unchanged.
- Keep Lootr's entity-tag and `ILootrEntity` hopper protection unchanged for actual entities.
- Add focused regression coverage for null, non-entity, ordinary entity, tagged Lootr entity, and resolved `ILootrEntity` results.

## Root cause

`MixinHopperBlockEntity.lootr$preventHopperEntityInteraction` wraps a method whose return type is `Container`, but it unconditionally cast that result to `Entity`. Backpacked 3.0.5's Hopper Bridge can return a `BackpackInventory`, which is a valid `Container` but not an `Entity`, causing a `ClassCastException` when a hopper minecart probes the nearby backpack.

This backports the same pattern-`instanceof` guard already accepted for newer Lootr branches in #861 and #862 to `mdg-1.21.1`.

## Validation

- `:fabric:test`: 5 tests, 0 failures
- `:fabric:build`: successful, including access-widener validation
- Live Fabric 1.21.1 dedicated-server testing with Backpacked 3.0.5:
  - Hopper Bridge interaction with a hopper minecart works without crashing
  - ordinary hopper transfers remain functional
  - Lootr hopper protection remains functional
  - server startup and client connection succeed
